### PR TITLE
Add mailmap (via subtree) to aid git shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+mailmap/.mailmap

--- a/mailmap/.mailmap
+++ b/mailmap/.mailmap
@@ -1,0 +1,35 @@
+Andy Howlett <andyhowlett@googlemail.com> AndyHowlett <andyhowlett@googlemail.com>
+Andy Howlett <andyhowlett@googlemail.com> AndyHowlett <none@none>
+Chris Hartgerink <chartgerink@users.noreply.github.com>
+Chris Hartgerink <chjh@protonmail.com> C.H.J. Hartgerink <u1233095@campus.uvt.nl>
+Chris Hartgerink <chjh@protonmail.com> CHJ Hartgerink <chjh@protonmail.com>
+Chris Hartgerink <chjh@protonmail.com> Chris Hartgerink <chartgerink@users.noreply.github.com>
+Chris Hartgerink <chjh@protonmail.com> chjh <chjh@localhost.localdomain>
+Christopher Kittel <web@christopherkittel.eu> <c.kittel@online.de>
+Christopher Kittel <web@christopherkittel.eu> Christopher KIttel <web@christopherkittel.eu>
+Christopher Kittel <web@christopherkittel.eu> chreman <web@christopherkittel.eu>
+Jim Downing <none@none> jimdowning <none@none>
+Mark Williamson <mw529@cam.ac.uk> Mark Williamson <mjw@mjw.name>
+Mark Williamson <mw529@cam.ac.uk> mjw@mjw.name <mjw@mjw.name>
+Murray Jensen <Murray.Jensen@csiro.au> mjjensen <none@none>
+Nick England <nickengland@gmail.com> nickengland <none@none>
+Nick England <nickengland@gmail.com> nwe23 <none@none>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> Peter Murray-Rust <pm286@cam.ac.uk>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> petemer <none@none>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> peter <none@none>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> peter <petermr@users.noreply.github.com>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> peter,r <none@none>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> peterm <none@none>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> peterme <none@none>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> petermmr <petermr@users.noreply.github.com>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> petermr <none@none>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> petermr <peter.murray.rust@googlemail.com>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> petermr <petermr@users.noreply.github.com>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> petrmr <none@none>
+Peter Murray-Rust <peter.murray.rust@googlemail.com> pm286 <none@none>
+Richard Smith-Unna <richardsmith404@gmail.com> Richard Smith-Unna <rds45@cam.ac.uk>
+Sam E. Adams <sea36@cam.ac.uk> sea36 <none@none>
+Thomas Arrow <thomasarrow@gmail.com> Thomas Arrow <tom@contentmine.org>
+Thomas Arrow <thomasarrow@gmail.com> Tom Arrow <bomarrow1@gmail.com>
+Thomas Arrow <thomasarrow@gmail.com> tarrow <tarrow@users.noreply.github.com>
+Weerapong Phadungsukanan <wp214@cam.ac.uk> wp214 <none@none>

--- a/mailmap/README.md
+++ b/mailmap/README.md
@@ -1,0 +1,1 @@
+# mailmap


### PR DESCRIPTION
Add from https://github.com/contentmine/mailmap using the manual
git subtree method.

If you are unfamiliar with the latter, see:
https://medium.com/@porteneuve/mastering-git-subtrees-943d29a798ec
or see this archived version of that tutorial:
https://web.archive.org/web/20170614142753/https://medium.com/@porteneuve/mastering-git-subtrees-943d29a798ec

Partially solves https://github.com/ContentMine/meta/issues/13 .