### PR TITLE
Uclii tables

### DIFF
--- a/src/main/java/org/xmlcml/pdf2svg/PDF2SVGConverter.java
+++ b/src/main/java/org/xmlcml/pdf2svg/PDF2SVGConverter.java
@@ -55,7 +55,7 @@ public class PDF2SVGConverter extends PDFStreamEngine {
 	private final static Logger LOG = Logger.getLogger(PDF2SVGConverter.class);
 
 	private static final String PDF = ".pdf";
-	private static final double _DEFAULT_PAGE_WIDTH = 600.0;
+	private static final double _DEFAULT_PAGE_WIDTH = 800.0;
 	private static final double _DEFAULT_PAGE_HEIGHT = 800.0;
 	
 	@SuppressWarnings("unused")

--- a/src/main/java/org/xmlcml/pdf2svg/PDFPage2SVGConverter.java
+++ b/src/main/java/org/xmlcml/pdf2svg/PDFPage2SVGConverter.java
@@ -166,7 +166,6 @@ public class PDFPage2SVGConverter extends PageDrawer {
 	
 	void drawPage(PDPage p) {
 		LOG.trace("startPage");
-		ensurePageSize();
 		page = p;
 		reportedEncodingError = false;
 
@@ -313,6 +312,7 @@ xmlns="http://www.w3.org/2000/svg">
 				pageSize = mediaBox == null ? null : mediaBox.createDimension();
 				pageSize = pageSize == null ? DEFAULT_DIMENSION : pageSize;
 				LOG.trace("set dimension: "+pageSize);
+                                LOG.debug("set dimension: "+pageSize);
 			}
 		}
 	}


### PR DESCRIPTION
Short-term changes to ensure table content is not truncated when the publisher has used a landscape page within a PDF document to accommodate a wide table.  This is a distinct use-case to tables published as 90 degree-rotated content on portrait-format pages, although a general solution under development will tackle both. 