### PR TITLE
Table clipper functionality (norma-0.7.0-alpha) and supporting analysis code

### DIFF
--- a/PDF2SVGTransformer.java
+++ b/PDF2SVGTransformer.java
@@ -1,0 +1,108 @@
+package org.contentmine.pdf2svg;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.xmlcml.graphics.svg.GraphicsElement;
+import org.xmlcml.graphics.svg.SVGSVG;
+import org.xmlcml.xml.XMLUtil;
+
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+
+/**
+ * new version of PDF2SVGConverter for PDFBox 2.0
+ * 
+ * @author pm286
+ *
+ */
+public class PDF2SVGTransformer {
+	private static final Logger LOG = Logger.getLogger(PDF2SVGTransformer.class);
+	static {
+		LOG.setLevel(Level.DEBUG);
+	}
+
+	private PDDocument document;
+	private PDFRenderer renderer;
+	private int pageCount;
+	StringBuilder debugBuilder;
+	private SVGSVG svgBuilder;
+//	private Real2 currentPoint = new Real2(0.0, 0.0); // to avoid null pointer
+	private Multiset<String> glyphSet;
+	private Multiset<String> codePointSet;
+	private double eps = 0.000001;
+	private PDFPage2SVGConverter pdfPage2SVGConverter;
+
+	public PDF2SVGTransformer() {
+        this.debugBuilder = new StringBuilder();
+        this.svgBuilder = new SVGSVG();
+        this.glyphSet = HashMultiset.create();
+        this.codePointSet = HashMultiset.create();
+	}
+
+	private void ensureCodePointSet() {
+		if (codePointSet == null) {
+	    	codePointSet = HashMultiset.create();
+    	}
+	}
+
+	public void convert(File file) throws IOException {
+		String fileRoot = FilenameUtils.getBaseName(file.toString());
+        document = PDDocument.load(file);
+        renderer = new PDFRenderer(document);
+        pageCount = document.getNumberOfPages();
+        LOG.info("Page count: "+pageCount);
+        for (int ipage = 0; ipage < pageCount; ipage++) {
+	        PDPage page = document.getPage(ipage);
+	        LOG.info("page: "+ipage);
+	        pdfPage2SVGConverter = new PDFPage2SVGConverter(this, renderer, page);
+	        pdfPage2SVGConverter.processPage();
+	        GraphicsElement svgElement = pdfPage2SVGConverter.getSVG();
+	        this.writePage(new File("target/debug/"+fileRoot+"/page_"+ipage+".txt"));
+	        XMLUtil.debug(svgElement, new FileOutputStream(new File("target/debug/"+fileRoot+"/page_"+ipage+".svg")), 1);
+        }
+        LOG.info("CodePoints "+codePointSet);
+        document.close();
+	}
+	
+	private void writeSVG(File file) throws IOException {
+		LOG.info("wrote: "+file.getAbsolutePath());
+		XMLUtil.debug(svgBuilder, file, 1);
+		svgBuilder = new SVGSVG();
+	}
+
+	public void writePage(File file) throws IOException {
+		LOG.info("wrote: "+file.getAbsolutePath());
+		FileUtils.write(file, debugBuilder.toString());
+		debugBuilder = new StringBuilder();
+	}
+
+	public void append(GraphicsElement element) {
+		getPdfPage2SVGConverter().appendChild(element);
+	}
+
+	public void addCodePoint(String codePointS) {
+		ensureCodePointSet();
+		codePointSet.add(codePointS);
+	}
+
+	public double getEpsilon() {
+		return eps;
+	}
+
+	public PDFPage2SVGConverter getPdfPage2SVGConverter() {
+		if (pdfPage2SVGConverter == null) {
+			throw new RuntimeException("Must create PDFPage2SVGConverter before now");
+		}
+		return pdfPage2SVGConverter;
+	}
+	
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,9 +14,12 @@
 
     <properties>
         <!-- upstream -->
-         <svg2xml.version>2.4.0-SNAPSHOT</svg2xml.version>
+         <svg2xml.version>2.4.0-SNAPSHOT</svg2xml.version> <!-- not used -->
+         
+         <svghtml.version>1.0.0-SNAPSHOT</svghtml.version>
         <pdfbox.version>1.8.8</pdfbox.version>
         <bcprov-jdk16.version>1.46</bcprov-jdk16.version>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 <!--  old version for compatibility -->    
@@ -36,10 +39,19 @@
             <version>${pdfbox.version}</version>
         </dependency>
 
+<!--  order is svghtml , svg2xml , cproject -->
+<!-- 
         <dependency>
             <groupId>org.contentmine</groupId>
             <artifactId>svg2xml</artifactId>
             <version>${svg2xml.version}</version>
+        </dependency>
+-->
+
+        <dependency>
+            <groupId>org.contentmine</groupId>
+            <artifactId>svghtml</artifactId>
+            <version>${svghtml.version}</version>
         </dependency>
         
         <dependency>
@@ -58,9 +70,14 @@
                 <version>1.8.1</version>
                 <configuration>
                     <programs>
+                    <!-- probably fails -->
                         <program>
                             <mainClass>org.xmlcml.svg2xml.PDFAnalyzer</mainClass>
                             <id>pdf2xml</id>
+                        </program>
+                        <program>
+                            <mainClass>org.xmlcml.pdf2svg.PDF2SVGConverter</mainClass>
+                            <id>pdf2svg</id>
                         </program>
 
                     </programs>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <name>pdf2svg</name>
     <description>Converts PDF to SVG</description>
 
+
     <!-- remove <repositories> for releases to maven central -->
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,17 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <pdf2svg.version>2.3.0-SNAPSHOT</pdf2svg.version>
         <!-- upstream -->
-<!--         <html.version>2.2.0-SNAPSHOT</html.version> -->
-         <svghtml.version>2.2.0-SNAPSHOT</svghtml.version> -->
+         <svg2xml.version>2.4.0-SNAPSHOT</svg2xml.version>
         <pdfbox.version>1.8.8</pdfbox.version>
+        <bcprov-jdk16.version>1.46</bcprov-jdk16.version>
     </properties>
-    
-    <groupId>org.contentmine</groupId>
+
+<!--  old version for compatibility -->    
+<!--     <groupId>org.contentmine</groupId> -->
+    <groupId>org.xmlcml</groupId>
     <artifactId>pdf2svg</artifactId>
-    <version>${pdf2svg.version}</version>
+    <version>2.4.0-SNAPSHOT</version>
     <name>pdf2svg</name>
     <description>Converts PDF to SVG</description>
 
@@ -37,14 +38,14 @@
 
         <dependency>
             <groupId>org.contentmine</groupId>
-            <artifactId>svghtml</artifactId>
-            <version>${svghtml.version}</version>
+            <artifactId>svg2xml</artifactId>
+            <version>${svg2xml.version}</version>
         </dependency>
         
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk16</artifactId>
-            <version>1.46</version>
+            <version>${bcprov-jdk16.version}</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
          <svg2xml.version>2.4.0-SNAPSHOT</svg2xml.version>
         <pdfbox.version>1.8.8</pdfbox.version>
         <bcprov-jdk16.version>1.46</bcprov-jdk16.version>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 <!--  old version for compatibility -->    

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <pdf2svg.version>2.2.0-SNAPSHOT</pdf2svg.version>
+        <pdf2svg.version>2.3.0-SNAPSHOT</pdf2svg.version>
         <!-- upstream -->
-        <html.version>2.2.0-SNAPSHOT</html.version>
+<!--         <html.version>2.2.0-SNAPSHOT</html.version> -->
+         <svghtml.version>2.2.0-SNAPSHOT</svghtml.version> -->
         <pdfbox.version>1.8.8</pdfbox.version>
     </properties>
     
@@ -36,8 +37,8 @@
 
         <dependency>
             <groupId>org.contentmine</groupId>
-            <artifactId>html</artifactId>
-            <version>${html.version}</version>
+            <artifactId>svghtml</artifactId>
+            <version>${svghtml.version}</version>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <pdf2svg.version>2.1.0</pdf2svg.version>
+        <pdf2svg.version>2.2.0-SNAPSHOT</pdf2svg.version>
         <!-- upstream -->
-        <html.version>2.1.0</html.version>
+        <html.version>2.2.0-SNAPSHOT</html.version>
         <pdfbox.version>1.8.8</pdfbox.version>
     </properties>
     

--- a/src/main/java/org/xmlcml/pdf2svg/PDF2SVGConverter.java
+++ b/src/main/java/org/xmlcml/pdf2svg/PDF2SVGConverter.java
@@ -55,7 +55,7 @@ public class PDF2SVGConverter extends PDFStreamEngine {
 	private final static Logger LOG = Logger.getLogger(PDF2SVGConverter.class);
 
 	private static final String PDF = ".pdf";
-	private static final double _DEFAULT_PAGE_WIDTH = 600.0;
+	private static final double _DEFAULT_PAGE_WIDTH = 800.0;
 	private static final double _DEFAULT_PAGE_HEIGHT = 800.0;
 	
 	@SuppressWarnings("unused")

--- a/src/main/java/org/xmlcml/pdf2svg/PDFPage2SVGConverter.java
+++ b/src/main/java/org/xmlcml/pdf2svg/PDFPage2SVGConverter.java
@@ -77,6 +77,7 @@ import org.xmlcml.graphics.svg.SVGShape;
 import org.xmlcml.graphics.svg.SVGText;
 import org.xmlcml.graphics.svg.SVGTitle;
 import org.xmlcml.graphics.svg.SVGUtil;
+import org.xmlcml.graphics.svg.util.ImageIOUtil;
 import org.xmlcml.pdf2svg.util.PDF2SVGUtil;
 
 /** converts a PDPage to SVG
@@ -1103,7 +1104,7 @@ xmlns="http://www.w3.org/2000/svg">
 			filename = createImageFilename();
 			File imageFile =  imageDirectory == null ? null : new File(imageDirectory, filename);
 			LOG.debug("imageFile "+imageFile);
-			org.xmlcml.graphics.image.ImageIOUtil.writeImageQuietly(bImage, imageFile);
+			ImageIOUtil.writeImageQuietly(bImage, imageFile);
 		}
 		return filename;
 	}

--- a/src/main/java/org/xmlcml/pdf2svg/PDFPage2SVGConverter.java
+++ b/src/main/java/org/xmlcml/pdf2svg/PDFPage2SVGConverter.java
@@ -167,7 +167,6 @@ public class PDFPage2SVGConverter extends PageDrawer {
 	
 	void drawPage(PDPage p) {
 		LOG.trace("startPage");
-		ensurePageSize();
 		page = p;
 		reportedEncodingError = false;
 
@@ -314,6 +313,7 @@ xmlns="http://www.w3.org/2000/svg">
 				pageSize = mediaBox == null ? null : mediaBox.createDimension();
 				pageSize = pageSize == null ? DEFAULT_DIMENSION : pageSize;
 				LOG.trace("set dimension: "+pageSize);
+                                LOG.debug("set dimension: "+pageSize);
 			}
 		}
 	}

--- a/src/main/java/org/xmlcml/pdf2svg/util/MenuSystem.java
+++ b/src/main/java/org/xmlcml/pdf2svg/util/MenuSystem.java
@@ -20,18 +20,18 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
 
-import nu.xom.Attribute;
-
 import org.apache.log4j.Logger;
 import org.xmlcml.euclid.Util;
-import org.xmlcml.html.HtmlA;
-import org.xmlcml.html.HtmlFrame;
-import org.xmlcml.html.HtmlFrameset;
-import org.xmlcml.html.HtmlHtml;
-import org.xmlcml.html.HtmlLi;
-import org.xmlcml.html.HtmlUl;
+import org.xmlcml.graphics.html.HtmlA;
+import org.xmlcml.graphics.html.HtmlFrame;
+import org.xmlcml.graphics.html.HtmlFrameset;
+import org.xmlcml.graphics.html.HtmlHtml;
+import org.xmlcml.graphics.html.HtmlLi;
+import org.xmlcml.graphics.html.HtmlUl;
 import org.xmlcml.xml.XMLConstants;
 import org.xmlcml.xml.XMLUtil;
+
+import nu.xom.Attribute;
 
 
 public class MenuSystem {
@@ -45,7 +45,7 @@ public class MenuSystem {
 	private static final String MENU = "menu";
 
 	private static final int DEFAULT_ROW_WIDTH = 100;
-	private static final String target = PConstants.HTML_TARGET;
+	private static final String target = org.xmlcml.pdf2svg.util.PConstants.HTML_TARGET;
 
 	private HtmlUl ul;
 	private File outdir;


### PR DESCRIPTION
The Table Clipper development (norma-0.7.0-alpha and stack of dependencies) has been delivered.  This includes underlying code developed by PMR under the general heading of '201704gfx'.

The current ContentMine TableClipper feature branch (across euclid, cproject, svghtml, svg2xml, pdf2svg, imageanalysis, norma) represents a stable codebase with many new features added since the current master and some refactoring.  It is a good opportunity to merge before further development work packages.
